### PR TITLE
[main@27e3608] Update AL-Go System Files from microsoft/AL-Go-PTE@preview - 1ee4778

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.AL-Go/localDevEnv.ps1
+++ b/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -18,5 +18,5 @@
   "doNotPublishApps": true,
   "doNotSignApps": true,
   "keyVaultCodesignCertificateName": "FreddyKristiansen",
-  "templateSha": "8fedaa0bba2cf96f8b2b0c57b7d4ba88e9c7069b"
+  "templateSha": "1ee47784d064e41a0e2fafc9fe6574bc36b8706f"
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,3 +1,27 @@
+## preview
+
+Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.
+
+### Security
+
+- Add top-level permissions for _Increment Version Number_ workflow
+
+### Issues
+
+- Issue 1697 Error in CheckForUpdates: "Internet Explorer engine is not available" when using self-hosted runners
+
+### Test settings against a JSON schema
+
+AL-Go for GitHub settings now has a schema. The following line is added at the beginning to any AL-Go settings files to utilize the schema:
+
+```
+"$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/<version>/Actions/settings.schema.json"
+```
+
+### Failing pull requests if new warnings are added
+
+By setting failOn to 'newWarning', pull requests will fail if new warnings are introduced. This feature compares the warnings in the pull request build against those in the latest successful CI/CD build and fails if new warnings are detected.
+
 ## v7.1
 
 ### Issues

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -50,18 +50,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -69,7 +69,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
-        uses: microsoft/AL-Go-Actions/AddExistingApp@v7.1
+        uses: microsoft/AL-Go/Actions/AddExistingApp@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -48,7 +48,7 @@ jobs:
       powerPlatformSolutionFolder: ${{ steps.DeterminePowerPlatformSolutionFolder.outputs.powerPlatformSolutionFolder }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -59,13 +59,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: type,powerPlatformSolutionFolder,useGitSubmodules
@@ -73,7 +73,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -115,7 +115,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -133,7 +133,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -149,21 +149,21 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -219,7 +219,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -228,7 +228,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v7.1
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           artifacts: '.artifacts'
@@ -265,7 +265,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -279,7 +279,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -287,7 +287,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v7.1
+        uses: microsoft/AL-Go/Actions/Deploy@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -299,7 +299,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v7.1
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -327,20 +327,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v7.1
+        uses: microsoft/AL-Go/Actions/Deliver@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -360,7 +360,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -60,19 +60,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: type
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -80,7 +80,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
-        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
+        uses: microsoft/AL-Go/Actions/CreateApp@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -50,7 +50,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -59,19 +59,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -90,7 +90,7 @@ jobs:
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -112,13 +112,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -137,7 +137,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v7.1
+        uses: microsoft/AL-Go/Actions/CreateDevelopmentEnvironment@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -57,7 +57,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -66,18 +66,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -85,7 +85,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
+        uses: microsoft/AL-Go/Actions/CreateApp@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -78,7 +78,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -87,20 +87,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: templateUrl,repoName,type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -109,12 +109,12 @@ jobs:
 
       - name: Determine Projects
         id: determineProjects
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           templateUrl: ${{ env.templateUrl }}
@@ -209,7 +209,7 @@ jobs:
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v7.1
+        uses: microsoft/AL-Go/Actions/CreateReleaseNotes@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           buildVersion: ${{ github.event.inputs.buildVersion }}
@@ -244,6 +244,7 @@ jobs:
   UploadArtifacts:
     needs: [ CreateRelease ]
     runs-on: [ ubuntu-latest ]
+    name: Upload ${{ matrix.name }}
     strategy:
       matrix: ${{ fromJson(needs.CreateRelease.outputs.artifacts) }}
       fail-fast: true
@@ -252,13 +253,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -296,7 +297,7 @@ jobs:
             });
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go-Actions/Deliver@v7.1
+        uses: microsoft/AL-Go/Actions/Deliver@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -309,7 +310,7 @@ jobs:
           atypes: 'Apps,TestApps'
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go-Actions/Deliver@v7.1
+        uses: microsoft/AL-Go/Actions/Deliver@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -353,13 +354,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -367,7 +368,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v7.1
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -385,7 +386,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -62,18 +62,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -81,7 +81,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v7.1
+        uses: microsoft/AL-Go/Actions/CreateApp@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -32,7 +32,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -43,13 +43,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -57,7 +57,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,18 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -54,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v7.1
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           artifacts: 'latest'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -34,6 +34,9 @@ env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
+permissions:
+  contents: read
+
 jobs:
   IncrementVersionNumber:
     needs: [ ]
@@ -45,7 +48,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -54,18 +57,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -73,7 +76,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v7.1
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -84,7 +87,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -32,7 +32,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -43,13 +43,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -57,7 +57,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -32,7 +32,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -43,13 +43,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: useGitSubmodules,shortLivedArtifactsRetentionDays
@@ -57,7 +57,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -36,7 +36,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -45,19 +45,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: pwsh
@@ -107,7 +107,7 @@ jobs:
             Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v7.1/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -141,21 +141,21 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
 
       - name: Get Artifacts for deployment
-        uses: microsoft/AL-Go-Actions/GetArtifactsForDeployment@v7.1
+        uses: microsoft/AL-Go/Actions/GetArtifactsForDeployment@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ matrix.shell }}
           artifactsVersion: ${{ github.event.inputs.appVersion }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v7.1
+        uses: microsoft/AL-Go/Actions/Deploy@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -176,7 +176,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go-Actions/DeployPowerPlatform@v7.1
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -195,7 +195,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v7.1
+      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
 
   Initialization:
     needs: [ PregateCheck ]
@@ -45,7 +45,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -57,13 +57,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: shortLivedArtifactsRetentionDays
@@ -76,7 +76,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v7.1
+        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -122,7 +122,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go-Actions/Troubleshooting@v7.1
+        uses: microsoft/AL-Go/Actions/Troubleshooting@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -48,14 +48,14 @@ jobs:
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: templateUrl
 
       - name: Get Workflow Multi-Run Branches
         id: GetBranches
-        uses: microsoft/AL-Go-Actions/GetWorkflowMultiRunBranches@v7.1
+        uses: microsoft/AL-Go/Actions/GetWorkflowMultiRunBranches@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           includeBranches: ${{ github.event.inputs.includeBranches }}
@@ -76,7 +76,7 @@ jobs:
   UpdateALGoSystemFiles:
     name: "[${{ matrix.branch }}] Update AL-Go System Files"
     needs: [ Initialize ]
-    runs-on: [ ubuntu-latest ]
+    runs-on: windows-latest
     strategy:
       matrix:
         branch: ${{ fromJson(needs.Initialize.outputs.UpdateBranches).branches }}
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v7.1
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
@@ -95,19 +95,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           get: commitOptions
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: pwsh
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -134,7 +134,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v7.1
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -148,7 +148,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v7.1
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -99,7 +99,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go-Actions/DetermineBuildProject@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineBuildProject@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -118,7 +118,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && github.event_name != 'pull_request'
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v7.1
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -136,7 +136,7 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v7.1
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -151,7 +151,7 @@ jobs:
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v7.1
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -162,7 +162,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go-Actions/RunPipeline@v7.1
+        uses: microsoft/AL-Go/Actions/RunPipeline@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -180,7 +180,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
-        uses: microsoft/AL-Go-Actions/Sign@v7.1
+        uses: microsoft/AL-Go/Actions/Sign@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -188,7 +188,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v7.1
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -273,8 +273,8 @@ jobs:
 
       - name: Analyze Test Results
         id: analyzeTestResults
-        if: (success() || failure()) && env.doNotRunTests == 'False' && ((hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '') || (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != ''))
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
+        if: (success() || failure()) && env.doNotRunTests == 'False'
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -283,7 +283,7 @@ jobs:
       - name: Analyze BCPT Test Results
         id: analyzeTestResultsBCPT
         if: (success() || failure()) && env.doNotRunBcptTests == 'False'
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -292,7 +292,7 @@ jobs:
       - name: Analyze Page Scripting Test Results
         id: analyzeTestResultsPageScripting
         if: (success() || failure()) && env.doNotRunpageScriptingTests == 'False'
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v7.1
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -300,7 +300,7 @@ jobs:
 
       - name: Cleanup
         if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v7.1
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}


### PR DESCRIPTION
## preview

Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.

### Security

- Add top-level permissions for _Increment Version Number_ workflow

### Issues

- Issue 1697 Error in CheckForUpdates: "Internet Explorer engine is not available" when using self-hosted runners

### Test settings against a JSON schema

AL-Go for GitHub settings now has a schema. The following line is added at the beginning to any AL-Go settings files to utilize the schema:

```
"$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/<version>/Actions/settings.schema.json"
```

### Failing pull requests if new warnings are added

By setting failOn to 'newWarning', pull requests will fail if new warnings are introduced. This feature compares the warnings in the pull request build against those in the latest successful CI/CD build and fails if new warnings are detected.
